### PR TITLE
remove namespace for APIs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,7 +11,7 @@ option(P2RNG_ENABLE_BENCHMARKS "Enable benchmarks ?" ON)
 #
 project(
   p2rng
-  VERSION 0.2.0
+  VERSION 0.3.0
   DESCRIPTION "A modern header-only C++ library for parallel algorithmic (pseudo) random number generation supporting OpenMP, CUDA, ROCm and oneAPI"
   LANGUAGES CXX
 )

--- a/perf/benchmarks_cuda.cu
+++ b/perf/benchmarks_cuda.cu
@@ -14,7 +14,7 @@ const unsigned long seed_pi{3141592654};
 // generate() algortithm
 
 template <class T>
-void generate_p2rng_cuda(benchmark::State& st)
+void p2rng_generate_cuda(benchmark::State& st)
 {   size_t n = size_t(st.range());
     cudaEvent_t start, stop;
     cudaEventCreate(&start); cudaEventCreate(&stop);
@@ -22,7 +22,7 @@ void generate_p2rng_cuda(benchmark::State& st)
 
     for (auto _ : st)
     {   cudaEventRecord(start);
-        p2rng::cuda::generate
+        p2rng::generate
         (   v.begin()
         ,   v.end()
         ,   p2rng::bind(trng::uniform_dist<T>(10, 100), pcg32(seed_pi))
@@ -41,13 +41,13 @@ void generate_p2rng_cuda(benchmark::State& st)
     );
 }
 
-BENCHMARK_TEMPLATE(generate_p2rng_cuda, float)
+BENCHMARK_TEMPLATE(p2rng_generate_cuda, float)
 ->  RangeMultiplier(2)
 ->  Range(1<<20, 1<<24)
 ->  UseManualTime()
 ->  Unit(benchmark::kMillisecond);
 
-BENCHMARK_TEMPLATE(generate_p2rng_cuda, double)
+BENCHMARK_TEMPLATE(p2rng_generate_cuda, double)
 ->  RangeMultiplier(2)
 ->  Range(1<<20, 1<<24)
 ->  UseManualTime()

--- a/perf/benchmarks_oneapi.cpp
+++ b/perf/benchmarks_oneapi.cpp
@@ -14,7 +14,7 @@ const unsigned long seed_pi{3141592654};
 // generate() algorithm
 
 template <class T>
-void generate_p2rng_oneapi(benchmark::State& st)
+void p2rng_generate_oneapi(benchmark::State& st)
 {   size_t n = size_t(st.range());
     // enabling SYCL queue profiling
     auto pl = sycl::property_list{sycl::property::queue::enable_profiling()};
@@ -22,7 +22,7 @@ void generate_p2rng_oneapi(benchmark::State& st)
     sycl::buffer<T> v(n);
 
     for (auto _ : st)
-    {   auto event = p2rng::oneapi::generate
+    {   auto event = p2rng::generate
         (   dpl::begin(v)
         ,   dpl::end(v)
         ,   p2rng::bind(trng::uniform_dist<T>(10, 100), pcg32(seed_pi))
@@ -42,13 +42,13 @@ void generate_p2rng_oneapi(benchmark::State& st)
     );
 }
 
-BENCHMARK_TEMPLATE(generate_p2rng_oneapi, float)
+BENCHMARK_TEMPLATE(p2rng_generate_oneapi, float)
 ->  RangeMultiplier(2)
 ->  Range(1<<20, 1<<24)
 ->  UseManualTime()
 ->  Unit(benchmark::kMillisecond);
 
-BENCHMARK_TEMPLATE(generate_p2rng_oneapi, double)
+BENCHMARK_TEMPLATE(p2rng_generate_oneapi, double)
 ->  RangeMultiplier(2)
 ->  Range(1<<20, 1<<24)
 ->  UseManualTime()

--- a/perf/benchmarks_openmp.cpp
+++ b/perf/benchmarks_openmp.cpp
@@ -15,7 +15,7 @@ const unsigned long seed_pi{3141592654};
 // generate() algorithm
 
 template <class T>
-void generate_stl(benchmark::State& st)
+void stl_generate(benchmark::State& st)
 {   size_t n = size_t(st.range());
     std::vector<T> v(n);
 
@@ -32,18 +32,18 @@ void generate_stl(benchmark::State& st)
     );
 }
 
-BENCHMARK_TEMPLATE(generate_stl, float)
+BENCHMARK_TEMPLATE(stl_generate, float)
 ->  RangeMultiplier(2)
 ->  Range(1<<20, 1<<24)
 ->  Unit(benchmark::kMillisecond);
 
-BENCHMARK_TEMPLATE(generate_stl, double)
+BENCHMARK_TEMPLATE(stl_generate, double)
 ->  RangeMultiplier(2)
 ->  Range(1<<20, 1<<24)
 ->  Unit(benchmark::kMillisecond);
 
 template <class T>
-void generate_p2rng_openmp(benchmark::State& st)
+void p2rng_generate_openmp(benchmark::State& st)
 {   size_t n = size_t(st.range());
     std::vector<T> v(n);
 
@@ -60,13 +60,13 @@ void generate_p2rng_openmp(benchmark::State& st)
     );
 }
 
-BENCHMARK_TEMPLATE(generate_p2rng_openmp, float)
+BENCHMARK_TEMPLATE(p2rng_generate_openmp, float)
 ->  RangeMultiplier(2)
 ->  Range(1<<20, 1<<24)
 ->  UseRealTime()
 ->  Unit(benchmark::kMillisecond);
 
-BENCHMARK_TEMPLATE(generate_p2rng_openmp, double)
+BENCHMARK_TEMPLATE(p2rng_generate_openmp, double)
 ->  RangeMultiplier(2)
 ->  Range(1<<20, 1<<24)
 ->  UseRealTime()

--- a/perf/benchmarks_rocm.cpp
+++ b/perf/benchmarks_rocm.cpp
@@ -14,7 +14,7 @@ const unsigned long seed_pi{3141592654};
 // generate() algortithm
 
 template <class T>
-void generate_p2rng_rocm(benchmark::State& st)
+void p2rng_generate_rocm(benchmark::State& st)
 {   size_t n = size_t(st.range());
     hipEvent_t start, stop;
     hipEventCreate(&start); hipEventCreate(&stop);
@@ -22,7 +22,7 @@ void generate_p2rng_rocm(benchmark::State& st)
 
     for (auto _ : st)
     {   hipEventRecord(start);
-        p2rng::rocm::generate
+        p2rng::generate
         (   v.begin()
         ,   v.end()
         ,   p2rng::bind(trng::uniform_dist<T>(10, 100), pcg32(seed_pi))
@@ -41,13 +41,13 @@ void generate_p2rng_rocm(benchmark::State& st)
     );
 }
 
-BENCHMARK_TEMPLATE(generate_p2rng_rocm, float)
+BENCHMARK_TEMPLATE(p2rng_generate_rocm, float)
 ->  RangeMultiplier(2)
 ->  Range(1<<20, 1<<24)
 ->  UseManualTime()
 ->  Unit(benchmark::kMillisecond);
 
-BENCHMARK_TEMPLATE(generate_p2rng_rocm, double)
+BENCHMARK_TEMPLATE(p2rng_generate_rocm, double)
 ->  RangeMultiplier(2)
 ->  Range(1<<20, 1<<24)
 ->  UseManualTime()

--- a/test/unit_tests_cuda.cu
+++ b/test/unit_tests_cuda.cu
@@ -49,9 +49,9 @@ TEMPLATE_TEST_CASE("generate() - CUDA", "[10K][pcg32]", float, double)
         ) );
     }
 
-    SECTION("p2rng::cuda::generate()")
+    SECTION("p2rng::generate()")
     {   thrust::device_vector<T> dvt(n);
-        p2rng::cuda::generate
+        p2rng::generate
         (   std::begin(dvt)
         ,   std::end(dvt)
         ,   p2rng::bind(u, pcg32(seed_pi))

--- a/test/unit_tests_oneapi.cpp
+++ b/test/unit_tests_oneapi.cpp
@@ -43,9 +43,9 @@ TEMPLATE_TEST_CASE( "generate() - oneAPI", "[10K][pcg32]", float, double )
         ) );
     }
 
-    SECTION("p2rng::oneapi::generate()")
+    SECTION("p2rng::generate()")
     {   sycl::buffer<T> dvt{sycl::range(n)};
-        p2rng::oneapi::generate
+        p2rng::generate
         (   dpl::begin(dvt)
         ,   dpl::end(dvt)
         ,   p2rng::bind(u, pcg32(seed_pi))

--- a/test/unit_tests_rocm.cpp
+++ b/test/unit_tests_rocm.cpp
@@ -49,9 +49,9 @@ TEMPLATE_TEST_CASE("generate() - ROCm", "[10K][pcg32]", float, double)
         ) );
     }
 
-    SECTION("p2rng::rocm::generate()")
+    SECTION("p2rng::generate()")
     {   thrust::device_vector<T> dvt(n);
-        p2rng::rocm::generate
+        p2rng::generate
         (   std::begin(dvt)
         ,   std::end(dvt)
         ,   p2rng::bind(u, pcg32(seed_pi))


### PR DESCRIPTION
The API namespaces (i.e. ::cuda, ::oneapi, ::rocm) are not necessary and have removed in this commit.